### PR TITLE
Возможность указать хост по умолчанию в конфигурации

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ If the integration is not in the list, you need to clear the browser cache.
 
 ```yaml
 ssh_command:
+  host: 192.168.1.123 # Optional
+  port: 22 # Optional
+  username: pi # Optional
+  password: raspberry # Optional
 ```
 
 ## Usage
@@ -38,6 +42,7 @@ script:
     - service: ssh_command.exec_command
       data:
         host: 192.168.1.123
+        port: 22
         user: pi
         pass: raspberry
         command: ls -la


### PR DESCRIPTION
Данные для подключения указываются только при конфигурации через yaml.
Как получилось: хотел указать креденшлы через `!secret my_username` - а при вызове службы это не катит. В связи с этим предлагаю такую модификацию.